### PR TITLE
Manually set gimbal yaw motor offset to 7100

### DIFF
--- a/application/gimbal_task.c
+++ b/application/gimbal_task.c
@@ -416,7 +416,7 @@ void set_cali_gimbal_hook(const uint16_t yaw_offset, const uint16_t pitch_offset
 {
   // Original:
   // gimbal_control.gimbal_yaw_motor.offset_ecd = yaw_offset;
-  gimbal_control.gimbal_yaw_motor.offset_ecd = 0x058d;
+  gimbal_control.gimbal_yaw_motor.offset_ecd = 7100;
   gimbal_control.gimbal_yaw_motor.max_relative_angle = max_yaw;
   gimbal_control.gimbal_yaw_motor.min_relative_angle = min_yaw;
 


### PR DESCRIPTION
- Value determined through actual testing
- Offset varies based on motor installation and gimbal center position
- Specific to the second infantry robot in 2024 season
- this value will Impacts the forward direction in autofollow mode